### PR TITLE
Update where_exists.gemspec

### DIFF
--- a/where_exists.gemspec
+++ b/where_exists.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdownq"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.2.22", "< 5"
+  s.add_dependency "rails", ">= 3.2.22"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
 end


### PR DESCRIPTION
I did not have a problem including this into my Rails 5 app. I don't believe that the gemspec needs to exclude Rails 5. Is there any reason not to make it available here? Are there any tests that won't pass under Rails 5?