### PR TITLE
Return all or none scope when build_exists_string produces no query

### DIFF
--- a/lib/where_exists.rb
+++ b/lib/where_exists.rb
@@ -20,7 +20,11 @@ module WhereExists
       not_string = "NOT "
     end
 
-    self.where("#{not_string}(#{queries_sql})")
+    if queries_sql.empty?
+      does_exist ? self.none : self.all
+    else
+      self.where("#{not_string}(#{queries_sql})")
+    end
   end
 
   def build_exists_string(association_name, *where_parameters, &block)

--- a/test/belongs_to_polymorphic_test.rb
+++ b/test/belongs_to_polymorphic_test.rb
@@ -61,6 +61,18 @@ class BelongsToPolymorphicTest < Minitest::Test
     assert_equal orphaned_child.id, result.first.id
   end
 
+  def test_no_entities_or_empty_child_relation
+    result = BelongsToPolymorphicChild.where_not_exists(:polymorphic_entity)
+    assert_equal 0, result.length
+
+    _first_child = BelongsToPolymorphicChild.create!
+    result = BelongsToPolymorphicChild.where_not_exists(:polymorphic_entity)
+    assert_equal 1, result.length
+
+    result = BelongsToPolymorphicChild.where_exists(:polymorphic_entity)
+    assert_equal 0, result.length
+  end
+
   def test_table_name_based_lookup
     first_entity = FirstPolymorphicEntity.create!
     second_entity = SecondPolymorphicEntity.create! id: first_entity.id + 1


### PR DESCRIPTION
This allows for the use of where_(not_)exists with a polymoprhic belongs_to on an empty relation.

We ran into the issue where `parent.transactions.where_not_exists(:document)' basically resulted in `SELECT * FROM transactions WHERE parent_id = 1234 AND (NOT ())`.

This fixes that case and a possible situation where, using the above example, no transactions have documents.
