### PR TITLE
Depend on activerecord directly, not Rails

### DIFF
--- a/where_exists.gemspec
+++ b/where_exists.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 5.2", "< 7.1"
+  s.add_dependency "activerecord", ">= 5.2", "< 7.1"
 
   s.add_development_dependency "sqlite3", "~> 1.4"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
WhereExists extends ActiveRecord. It is not a Railtie, and has nothing to do with the rest of Rails. Depending on ActiveRecord by way of Rails means that consumers of WhereExists must bring in the entirety of Rails, and not just the gems we use. Let's depend on ActiveRecord directly.