### PR TITLE
chore: activerecord version dependancy to any less than v8

### DIFF
--- a/where_exists.gemspec
+++ b/where_exists.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "activerecord", ">= 5.2", "<= 7.1"
+  s.add_dependency "activerecord", ">= 5.2", "<8"
 
   s.add_development_dependency "sqlite3", "~> 1.4"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
With the recent rails 7.1.1 release I found the current version restriction too tight. Would this simple change be acceptable or is there more involved?