### PR TITLE
Add support for composite keys

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -142,6 +142,10 @@ User.where_exists(:groups, &:approved)
 **A**: Yes.
 
 
+**Q**: Does it support composite (multi-column) foreign keys, e.g. `has_many :children, foreign_key: %i[foo bar], primary_key: %i[foo bar]`?<br>
+**A**: Yes. Each key column is matched individually with AND conditions in the EXISTS subquery.
+
+
 **Q**: Does it take into account default association condition, e.g. `has_many :drafts, -> { where published: nil }`?<br>
 **A**: Yes.
 

--- a/lib/where_exists.rb
+++ b/lib/where_exists.rb
@@ -73,13 +73,12 @@ module WhereExists
 
     queries = []
 
-    self_ids = quote_table_and_column_name(self.table_name, association.foreign_key)
     self_type = quote_table_and_column_name(self.table_name, association.foreign_type)
 
     associated_models.each do |associated_model|
       primary_key = association.options[:primary_key] || associated_model.primary_key
-      other_ids = quote_table_and_column_name(associated_model.table_name, primary_key)
-      query = associated_model.select("1").where("#{self_ids} = #{other_ids}")
+      join_condition = build_join_condition(self.table_name, association.foreign_key, associated_model.table_name, primary_key)
+      query = associated_model.select("1").where(join_condition)
       if where_parameters != []
         query = query.where(*where_parameters)
       end
@@ -138,10 +137,9 @@ module WhereExists
       foreign_key = association.foreign_key
     end
 
-    self_ids = quote_table_and_column_name(self.table_name, primary_key)
-    associated_ids = quote_table_and_column_name(associated_model.table_name, foreign_key)
+    join_condition = build_join_condition(associated_model.table_name, foreign_key, self.table_name, primary_key)
 
-    result = associated_model.select("1").where("#{associated_ids} = #{self_ids}")
+    result = associated_model.select("1").where(join_condition)
 
     if association.options[:as]
       other_types = quote_table_and_column_name(associated_model.table_name, association.type)
@@ -239,6 +237,19 @@ module WhereExists
     end
 
     nested ? str : [query.where(str)]
+  end
+
+  def build_join_condition(left_table, left_keys, right_table, right_keys)
+    left_keys = Array(left_keys)
+    right_keys = Array(right_keys)
+
+    conditions = left_keys.zip(right_keys).map do |lk, rk|
+      left_col = quote_table_and_column_name(left_table, lk)
+      right_col = quote_table_and_column_name(right_table, rk)
+      "#{left_col} = #{right_col}"
+    end
+
+    conditions.join(' AND ')
   end
 
   def quote_table_and_column_name(table_name, column_name)

--- a/test/has_many_composite_key_test.rb
+++ b/test/has_many_composite_key_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+ActiveRecord::Migration.create_table :composite_key_entities, force: true do |t|
+  t.integer :first_key
+  t.integer :second_key
+  t.string :name
+end
+
+ActiveRecord::Migration.create_table :composite_key_entity_children, force: true do |t|
+  t.integer :first_key
+  t.integer :second_key
+  t.string :name
+end
+
+class CompositeKeyEntity < ActiveRecord::Base
+  has_many :composite_key_entity_children,
+    foreign_key: %i[first_key second_key],
+    primary_key: %i[first_key second_key],
+    dependent: false,
+    inverse_of: false
+end
+
+class CompositeKeyEntityChild < ActiveRecord::Base
+end
+
+class HasManyCompositeKeyTest < Minitest::Test
+  def setup
+    CompositeKeyEntity.delete_all
+    CompositeKeyEntityChild.delete_all
+  end
+
+  def test_where_exists_with_composite_keys
+    entity = CompositeKeyEntity.create!(first_key: 1, second_key: 10, name: 'matched')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'child')
+
+    _no_match = CompositeKeyEntity.create!(first_key: 2, second_key: 20, name: 'unmatched')
+
+    result = CompositeKeyEntity.where_exists(:composite_key_entity_children)
+
+    assert_equal 1, result.length
+    assert_equal entity.id, result.first.id
+  end
+
+  def test_where_not_exists_with_composite_keys
+    _entity = CompositeKeyEntity.create!(first_key: 1, second_key: 10, name: 'matched')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'child')
+
+    no_match = CompositeKeyEntity.create!(first_key: 2, second_key: 20, name: 'unmatched')
+
+    result = CompositeKeyEntity.where_not_exists(:composite_key_entity_children)
+
+    assert_equal 1, result.length
+    assert_equal no_match.id, result.first.id
+  end
+
+  def test_where_exists_with_composite_keys_and_conditions
+    entity = CompositeKeyEntity.create!(first_key: 1, second_key: 10, name: 'matched')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'right')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'wrong')
+
+    _other = CompositeKeyEntity.create!(first_key: 3, second_key: 30, name: 'other')
+    CompositeKeyEntityChild.create!(first_key: 3, second_key: 30, name: 'wrong')
+
+    result = CompositeKeyEntity.where_exists(:composite_key_entity_children, name: 'right')
+
+    assert_equal 1, result.length
+    assert_equal entity.id, result.first.id
+  end
+
+  def test_where_exists_with_composite_keys_partial_match_does_not_match
+    # Only first_key matches, second_key differs — should NOT match
+    CompositeKeyEntity.create!(first_key: 1, second_key: 10, name: 'partial')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 99, name: 'child')
+
+    result = CompositeKeyEntity.where_exists(:composite_key_entity_children)
+
+    assert_equal 0, result.length
+  end
+
+  def test_where_exists_with_composite_keys_and_block
+    entity = CompositeKeyEntity.create!(first_key: 1, second_key: 10, name: 'matched')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'right')
+    CompositeKeyEntityChild.create!(first_key: 1, second_key: 10, name: 'wrong')
+
+    result = CompositeKeyEntity.where_exists(:composite_key_entity_children) { |scope|
+      scope.where(name: 'right')
+    }
+
+    assert_equal 1, result.length
+    assert_equal entity.id, result.first.id
+  end
+end


### PR DESCRIPTION
With composite primary/foreign keys, I noticed where_exists tried to build a query with parent.[col1, col2] = instead of generating two comparison joined by AND. This adds support for composite keys